### PR TITLE
Add the missing pip requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "prettytable>=3.10.0",
     "psutil>=7.0.0",
     "GitPython>=3.1.32",
-    "distro>=1.9.0"
+    "distro>=1.9.0",
+    "pip>=21.0.0"
 ]
 authors = [
     {name = "DataShades", email = "datashades@linkdigital.com.au"},


### PR DESCRIPTION
Error

<pre>
File "/app/venv/lib/python3.11/site-packages/ckanext/selfinfo/utils.py", line 103, in get_freeze
    from pip._internal.operations import freeze
ModuleNotFoundError: No module named 'pip'
</pre>